### PR TITLE
Added functionality for PR retrieving and notifying.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,16 @@ inputs:
       `$\{\{ github.event.workflow_run.id` variable \}\}` if used in `workflow_run` triggered run if
       you want to act on source workflow rather than the triggered run.
     required: false
+  notifyPRCancel:
+    description: |
+      Boolean. If set to true, it notifies the cancelled PRs with a comment containing reason why
+      they are being cancelled.
+    required: false
+  notifyPRMessageStart:
+    description: |
+      Only for workflow_run events triggered by the PRs. If not empty, it notifies those PRs with the
+      message specified at the start of the workflow - adding the link to the triggered workflow_run.
+    required: false
   cancelMode:
     description: |
       The mode of cancel. One of:


### PR DESCRIPTION
In case the workflow was triggered by a Pull Request,
it finds out the PR that triggered it and notifies it (controlled
by the parameters specified):

* when the workflow is started with specified message
* when any other PR is cancelled, it is notificed with
  explainiing the reason why it has been cancelled.