### PR TITLE
Adds self-preservation mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ If you want a comprehensive solution, you should use the action as follows:
 | `notifyPRMessageStart`   | no       |              | Only for workflow_run events triggered by the PRs. If not empty, it notifies those PRs with the message specified at the start of the workflow - adding the link to the triggered workflow_run.                  |
 | `jobNameRegexps`         | no       |              | An array of job name regexps. Only runs containing any job name matching any of of the regexp in this array are considered for cancelling in `failedJobs` and `namedJobs` and `allDuplicateNamedJobs` modes.     |
 | `skipEventTypes`         | no       |              | Array of event names that should be skipped when cancelling (JSON-encoded string). This might be used in order to skip direct pushes or scheduled events.                                                        |
+| `selfPreservation`       | no       | true         | Do not cancel self.                                                                                                                                                                                              |
 | `workflowFileName`       | no       |              | Name of the workflow file. It can be used if you want to cancel a different workflow than yours.                                                                                                                 |
 
 
@@ -566,6 +567,11 @@ match.
 Note that the match must be identical. If there are two jobs that have a different Branch
 they will both match the same pattern, but they are not considered duplicates.
 
+Also, this is one of the jobs It has also self-preservation turned off.
+This means that in case the job determines that it is itself a duplicate it will cancel itself. That's
+why checking for duplicates of self-workflow should be the last step in the cancelling process.
+
+
 ```yaml
 on:
   push:
@@ -584,7 +590,9 @@ jobs:
           cancelMode: allDuplicatedNamedJobs
           token: ${{ secrets.GITHUB_TOKEN }}
           jobNameRegexps: '["Branch: .* Repo: .* Event: .* "]'
+          selfPreservation: false
           notifyPRCancel: true
+
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,11 @@ inputs:
       In case of duplicate canceling, cancel also future duplicates leaving only the "freshest" running
       job and not all the future jobs. By default it is set to true.
     required: false
+  selfPreservation:
+    description: |
+      Do not cancel your own run. There are cases where selfPreservation should be disabled but it is
+      enabled by default. You can disable it by setting 'false' as value.
+    required: false
   jobNameRegexps:
     description: |
       Array of job name regexps (JSON-encoded string). Used by `failedJobs` and `namedJobs` cancel modes


### PR DESCRIPTION
This mechanism is useful in some edge-cases, especially when you
re-run a build and you base the cancelling on named jobs, the
jobs might get the name in the previous run and when re-running,
the action might cancel its own run.